### PR TITLE
consume termcolors 0.6.0; add support for vscode export

### DIFF
--- a/lib/components/export.react.jsx
+++ b/lib/components/export.react.jsx
@@ -70,6 +70,7 @@ var Export = React.createClass({
             <option value='terminalapp'>Terminal.app</option>
             <option value='terminator'>Terminator</option>
             <option value='termite'>Termite</option>
+            <option value='vscode'>Visual Studio Code</option>
             <option value='xfce'>XFCE4 Terminal</option>
             <option value='xshell'>Xshell</option>
             <option value='xresources'>Xresources</option>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-colorpicker": "^0.3.9",
     "react-ranger": "^0.5.5",
     "reflux": "^0.2.5",
-    "termcolors": "^0.5.0",
+    "termcolors": "^0.6.0",
     "termio": "^1.0.0",
     "through": "^2.3.6",
     "urlsafe-base64": "^1.0.0"


### PR DESCRIPTION
consumes and is dependent on https://github.com/stayradiated/termcolors/pull/15

fixes #49