### PR TITLE
Add export support for Kitty

### DIFF
--- a/lib/components/export.react.jsx
+++ b/lib/components/export.react.jsx
@@ -63,6 +63,7 @@ var Export = React.createClass({
             <option value='guake'>Guake</option>
             <option value='iterm'>iTerm2</option>
             <option value='konsole'>Konsole</option>
+            <option value='kitty'>Kitty</option>
             <option value='linux'>Linux console</option>
             <option value='mintty'>MinTTY</option>
             <option value='putty'>Putty</option>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-colorpicker": "^0.3.9",
     "react-ranger": "^0.5.5",
     "reflux": "^0.2.5",
-    "termcolors": "^0.5.0",
+    "termcolors": "^0.7.2",
     "termio": "^1.0.0",
     "through": "^2.3.6",
     "urlsafe-base64": "^1.0.0"


### PR DESCRIPTION
Kitty was added in termcolors 0.7.2:
https://github.com/stayradiated/termcolors/commits/4efd2a994a9a5a19604c105f5b2840a45cc8b84d

I'm pretty sure I broke `yarn.lock`, but I wasn't able to build sass on my system.

See #73.

(Also, I'm pretty sure termcolors supports importing Kitty at that version.)